### PR TITLE
feat: Add frontend Dockerfile with Node + Vite

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,50 @@
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Build outputs
+dist/
+build/
+*.local
+
+# Testing
+coverage/
+.nyc_output/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+docs/
+*.md
+!README.md
+
+# Logs
+*.log
+logs/
+
+# OS
+Thumbs.db
+
+# Temporary files
+.tmp/
+temp/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,26 @@
+# Boston Government Services Frontend
+# Uses Node 18 and Vite for development
+
+FROM node:18-alpine AS development
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency files first for better layer caching
+# If package.json hasn't changed, Docker will use cached layers
+COPY package.json package-lock.json ./
+
+# Install dependencies using npm ci for reproducible builds
+# npm ci is faster and more reliable than npm install for CI/CD
+RUN npm ci
+
+# Copy the rest of the application
+COPY . .
+
+# Expose Vite dev server port
+EXPOSE 5173
+
+# Run Vite dev server
+# --host flag allows connections from outside the container
+# Note: vite.config.ts already has host: true, but CLI flag ensures compatibility
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary
Implements Issue #3: Create frontend Dockerfile with Node + Vite dev server.

Closes #3

## Changes
- ✅ Created `frontend/Dockerfile` with Node 18-alpine and Vite support
- ✅ Created `frontend/.dockerignore` to optimize build context
- ✅ Configured proper layer caching for faster rebuilds
- ✅ Added `--host` flag for Vite to accept external connections

## Implementation Details

**Dockerfile Features:**
- Base image: Node 18-alpine (AS development)
- Package manager: npm ci (faster, more reproducible than npm install)
- Layer caching: Copies package*.json before source code
- Port: 5173 (Vite default)
- CMD: npm run dev -- --host (accepts external connections)

**.dockerignore:**
- Excludes node_modules (rebuilt in container)
- Excludes build artifacts (dist/, build/)
- Excludes IDE, OS, and temporary files
- Consistent with backend .dockerignore pattern

## Test Results

✅ **Build Success**: No errors or warnings  
✅ **Image Size**: ~424MB (reasonable for Node + all dependencies)  
✅ **Node Version**: v18.20.8 (correct)  
✅ **npm ci**: Runs successfully  
✅ **Port**: 5173 exposed correctly  
✅ **docker-compose**: Compatible with existing configuration  

## Acceptance Criteria

All acceptance criteria from Issue #3 met:

- [x] Dockerfile at `frontend/Dockerfile`
- [x] Uses Node 18-alpine
- [x] npm install runs successfully (using npm ci)
- [x] Exposes port 5173
- [x] CMD runs `npm run dev -- --host`
- [x] Docker build succeeds with no errors
- [x] .dockerignore created for node_modules

## Design Decisions

1. **npm ci**: Used instead of npm install for faster, more reliable builds
2. **AS development**: Enables future multi-stage builds for production
3. **Layer caching**: package.json → npm ci → source code for optimal caching
4. **--host flag**: Required for Vite to accept connections from outside container

## Files Changed

```
frontend/.dockerignore  | 50 +++++++++++++++++++++++++++++++++++++++++++++++
frontend/Dockerfile     | 26 +++++++++++++++++++++++++
2 files changed, 76 insertions(+)
```

## Ready for QA Review

This PR is ready for QA agent review and sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>