### PR TITLE
feat(backend): Improve CORS configuration for flexible localhost port support in development

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,10 +1,16 @@
 # FastAPI Configuration
+# ENVIRONMENT: Determines CORS behavior
+#   - development: Allows any localhost port (flexible for Vite/React dev servers)
+#   - production: Requires explicit CORS_ORIGINS list (strict security)
 ENVIRONMENT=development
 DEBUG=true
 API_HOST=0.0.0.0
 API_PORT=8000
 
 # CORS Configuration
+# CORS_ORIGINS: Comma-separated list of allowed origins (REQUIRED in production)
+# In development mode, this is ignored in favor of flexible localhost regex
+# In production mode, this must be explicitly set for security
 CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 
 # Neo4j Configuration

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -88,7 +88,13 @@ class TestCORSConfiguration:
                 origin not in response.headers.get("access-control-allow-origin", "")
             )
 
-    @patch.dict(os.environ, {"ENVIRONMENT": "production", "CORS_ORIGINS": "https://example.com,https://app.example.com"})
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "production",
+            "CORS_ORIGINS": "https://example.com,https://app.example.com",
+        },
+    )
     def test_production_cors_requires_explicit_origins(self) -> None:
         """Test that production mode enforces strict origin list."""
         # Need to reimport to pick up new environment
@@ -129,7 +135,9 @@ class TestCORSConfiguration:
         import src.main
 
         # Reloading should raise ValueError during app initialization
-        with pytest.raises(ValueError, match="CORS_ORIGINS environment variable must be set in production"):
+        with pytest.raises(
+            ValueError, match="CORS_ORIGINS environment variable must be set in production"
+        ):
             importlib.reload(src.main)
 
     @patch.dict(os.environ, {"ENVIRONMENT": "production", "CORS_ORIGINS": "https://example.com"})

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,5 +1,9 @@
 """Tests for main FastAPI application endpoints."""
 
+import os
+from unittest.mock import patch
+
+import pytest
 from fastapi.testclient import TestClient
 
 from src import __version__
@@ -35,3 +39,116 @@ def test_redoc_available(test_client: TestClient) -> None:
     """Test that ReDoc documentation is available."""
     response = test_client.get("/redoc")
     assert response.status_code == 200
+
+
+class TestCORSConfiguration:
+    """Tests for CORS middleware configuration in different environments."""
+
+    def test_development_cors_allows_any_localhost_port(self, test_client: TestClient) -> None:
+        """Test that development mode allows requests from any localhost port."""
+        # Test various localhost ports
+        test_origins = [
+            "http://localhost:5173",
+            "http://localhost:5174",
+            "http://localhost:3000",
+            "http://localhost:8080",
+            "http://localhost:9999",
+        ]
+
+        for origin in test_origins:
+            response = test_client.options(
+                "/health",
+                headers={
+                    "Origin": origin,
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+            # CORS preflight should succeed for all localhost ports
+            assert response.status_code == 200
+            assert "access-control-allow-origin" in response.headers
+
+    def test_development_cors_rejects_non_localhost(self, test_client: TestClient) -> None:
+        """Test that development mode rejects non-localhost origins."""
+        non_localhost_origins = [
+            "http://example.com",
+            "https://malicious.com",
+            "http://192.168.1.1:5173",
+        ]
+
+        for origin in non_localhost_origins:
+            response = test_client.options(
+                "/health",
+                headers={
+                    "Origin": origin,
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+            # Should not have CORS headers for non-localhost
+            assert "access-control-allow-origin" not in response.headers or (
+                origin not in response.headers.get("access-control-allow-origin", "")
+            )
+
+    @patch.dict(os.environ, {"ENVIRONMENT": "production", "CORS_ORIGINS": "https://example.com,https://app.example.com"})
+    def test_production_cors_requires_explicit_origins(self) -> None:
+        """Test that production mode enforces strict origin list."""
+        # Need to reimport to pick up new environment
+        import importlib
+
+        import src.main
+
+        importlib.reload(src.main)
+
+        with TestClient(src.main.app) as client:
+            # Allowed origin should work
+            response = client.options(
+                "/health",
+                headers={
+                    "Origin": "https://example.com",
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+            assert response.status_code == 200
+            assert "access-control-allow-origin" in response.headers
+
+            # Disallowed origin should not have CORS headers
+            response = client.options(
+                "/health",
+                headers={
+                    "Origin": "https://malicious.com",
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+            # FastAPI returns 400 for disallowed origins in CORS preflight
+            assert response.status_code == 400
+
+    @patch.dict(os.environ, {"ENVIRONMENT": "production", "CORS_ORIGINS": ""})
+    def test_production_without_cors_origins_raises_error(self) -> None:
+        """Test that production mode raises error if CORS_ORIGINS not set."""
+        import importlib
+
+        import src.main
+
+        # Reloading should raise ValueError during app initialization
+        with pytest.raises(ValueError, match="CORS_ORIGINS environment variable must be set in production"):
+            importlib.reload(src.main)
+
+    @patch.dict(os.environ, {"ENVIRONMENT": "production", "CORS_ORIGINS": "https://example.com"})
+    def test_production_cors_blocks_localhost(self) -> None:
+        """Test that production mode blocks localhost origins."""
+        import importlib
+
+        import src.main
+
+        importlib.reload(src.main)
+
+        with TestClient(src.main.app) as client:
+            # Localhost should be blocked in production
+            response = client.options(
+                "/health",
+                headers={
+                    "Origin": "http://localhost:5173",
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+            # Should return 400 for disallowed origin
+            assert response.status_code == 400


### PR DESCRIPTION
## Summary
Implements flexible CORS configuration that allows development servers to run on any localhost port while maintaining strict security in production.

**Addresses:** Issue #64 (HIGH priority, user-requested)

## Changes

### 1. **CORS Middleware** (`backend/src/main.py`)
   - Added environment-aware CORS configuration
   - **Development mode**: Uses `allow_origin_regex=r"http://localhost:\d+"` to accept any localhost port
   - **Production mode**: Requires explicit `CORS_ORIGINS` environment variable with strict origin list
   - Production raises `ValueError` if `CORS_ORIGINS` not set, preventing accidental misconfiguration

### 2. **Documentation** (`backend/.env.example`)
   - Added comprehensive comments explaining CORS behavior in each environment
   - Documented that `ENVIRONMENT` variable controls CORS mode
   - Clarified `CORS_ORIGINS` is required in production, ignored in development

### 3. **Tests** (`backend/tests/test_main.py`)
   - Added comprehensive `TestCORSConfiguration` test class with 5 tests:
     - Development mode allows localhost:5173, localhost:5174, localhost:3000, etc.
     - Development mode rejects non-localhost origins (security)
     - Production mode enforces explicit origin list
     - Production mode raises error if CORS_ORIGINS not set
     - Production mode blocks localhost origins

## Testing Evidence

### Unit Tests
```
tests/test_main.py::TestCORSConfiguration::test_development_cors_allows_any_localhost_port PASSED
tests/test_main.py::TestCORSConfiguration::test_development_cors_rejects_non_localhost PASSED
tests/test_main.py::TestCORSConfiguration::test_production_cors_requires_explicit_origins PASSED
tests/test_main.py::TestCORSConfiguration::test_production_without_cors_origins_raises_error PASSED
tests/test_main.py::TestCORSConfiguration::test_production_cors_blocks_localhost PASSED

Coverage: 95% on src/main.py
```

### Type Checking
```
Success: no issues found in 1 source file
```

### Linting
```
All checks passed!
```

### Full Test Suite
```
356 passed, 150 warnings in 1.46s
```
(Note: 13 pre-existing integration test failures in graph_service_integration.py unrelated to CORS changes)

## Manual Verification

Tested scenarios:
- ✅ Development mode: Vite dev server works on ports 5173, 5174, 5175
- ✅ Development mode: Rejects non-localhost origins (security verified)
- ✅ Production mode: Requires explicit CORS_ORIGINS or raises clear error
- ✅ Production mode: Enforces strict origin list

## Security Considerations

**No security regression:**
- Production mode maintains strict origin validation (unchanged behavior)
- Development mode only allows `http://localhost:*` (not external IPs or domains)
- Defaults to production if `ENVIRONMENT` not set (fail-secure)
- Clear error message guides production deployment

**Benefits:**
- Eliminates frustration when Vite picks different ports (5173, 5174, etc.)
- No need to restart backend or update environment variables
- Maintains separation between dev flexibility and production security

## User Feedback Addressed

> "we need to be able to handle things running on multiple ports at least in dev and shouldnt just be hardcoding a single port"

This PR directly addresses this feedback by:
1. Using regex to match any localhost port in development
2. Removing hardcoded port requirements
3. Maintaining strict security in production

## Checklist

- ✅ Tests pass (356/356 non-integration tests)
- ✅ Type hints on all functions
- ✅ No security regression (production unchanged)
- ✅ Documentation updated (.env.example)
- ✅ Follows code style (ruff, mypy)
- ✅ Manual verification complete
- ✅ Backwards compatible (existing production deployments unaffected)

Closes #64